### PR TITLE
Fixed Prototype pollution bug in extra-object

### DIFF
--- a/src/setPath$.ts
+++ b/src/setPath$.ts
@@ -11,6 +11,9 @@ import getPath from './getPath';
  */
 function setPath$(x: object, p: string[], v: any): any {
   var y = getPath(x, p.slice(0, -1));
+  if (p.includes('__proto__') || p.includes('constructor') || p.includes('prototype')) {
+        return false;
+   }
   if(is(y)) y[last(p)] = v;
   return x;
 }


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-extra-object

### ⚙️ Description *

extra-object is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `p` in `setPath$()` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
var extraObject = require("extra-object")
var obj = {}
console.log("Before : " + {}.polluted);
extraObject.setPath$(obj, ['__proto__','polluted'],'Yes! Its Polluted' );
console.log("After : " + {}.polluted);
```

![image](https://user-images.githubusercontent.com/16708391/100206803-ced40500-2f2c-11eb-9f5e-d57f0ca5c0ac.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/100206964-06db4800-2f2d-11eb-8a08-0d7b185f0561.png)



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `p` and no breaking changes are introduced. :)
